### PR TITLE
src/tox.ini:  use abs path for `true` cmd in func-noop

### DIFF
--- a/src/tox.ini
+++ b/src/tox.ini
@@ -19,7 +19,7 @@ commands = charm-proof
 [testenv:func-noop]
 basepython = python3
 commands =
-    true
+    /bin/true
 
 [testenv:func]
 basepython = python3


### PR DESCRIPTION
When I run:

> tox -e func-noop

I get following warning:

func-noop run-test-pre: PYTHONHASHSEED='0'
func-noop run-test: commands[0] | true
WARNING: test command found but not installed in testenv
  cmd: /bin/true
  env: /mnt/masakari/build/builds/masakari/.tox/func-noop
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
____________________________________________________________________ summary _____________________________________________________________________
  func-noop: commands succeeded
  congratulations :)

Use abs path for true mute the warning.